### PR TITLE
fix mini-loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 name = "mini-loader"
 version = "1.1.0"
 dependencies = [
+ "elf",
  "elf_loader",
  "linked_list_allocator",
  "syscalls",

--- a/mini-loader/Cargo.toml
+++ b/mini-loader/Cargo.toml
@@ -13,8 +13,9 @@ categories = ["no-std", "os"]
 
 [dependencies]
 syscalls = { workspace = true }
-elf_loader = { path = "../", version = "0.9.0", features = ["fs", "mmap"] }
+elf_loader = { path = "../", version = "0.9.0", default-features = false, features = ["fs", "mmap", "use-syscall"] }
 linked_list_allocator = { version = "0.10.5" }
+elf = { version = "0.7.4", default-features = false }
 
 [[bin]]
 name = "mini-loader"


### PR DESCRIPTION
I followed mini-loader's [README](https://github.com/weizhiao/rust_elfloader/blob/main/mini-loader/README.md) but got segmentation fault. I spent some time on debugging and found two issues as follows:

1. According [libc's ABI](https://github.com/lattera/glibc/blob/895ef79e04a953cac1493863bcae29ad85657ee1/sysdeps/x86_64/start.S#L79), register RDX is the address of the termination function, so we need to add `xor rdx, rdx` to the trampoline.
2. Before relocation is done, mini-loader cannot call any functions. However, when using `ElfPhdr` and `ElfRela`, it calls `Deref` which causes segmentation fault. To fix it, I removed this indirection and use the actual types `Elf64_Phdr` and `Elf64_Rela` since it only supports x86_64.

Please let me know if you have any comments or suggestions.